### PR TITLE
Masterdata improve 1

### DIFF
--- a/tests/integration_tests/test_master_data_endpoint.py
+++ b/tests/integration_tests/test_master_data_endpoint.py
@@ -20,25 +20,40 @@ def user_profile_id():
     return os.environ.get("CUSTOMER_ID")
 
 
-@pytest.mark.skip("working for now")
+@pytest.fixture
+def acronym():
+    return "CL"
+
+
+# @pytest.mark.skip("working for now")
 def test_get_profile_by_email(client: Vtex, email):
     result = client.master_data.get_profile_by_email(email)
     assert result.status_code == OK
 
 
-@pytest.mark.skip("working for now")
+# @pytest.mark.skip("working for now")
 def test_get_profile_by_user_profile_id(client: Vtex, user_profile_id):
     result = client.master_data.get_profile_by_user_profile_id(user_profile_id)
     assert result.status_code == OK
 
 
-def test_get_clients_scroll(client: Vtex):
-    result = client.master_data.get_clients_scroll()
+def test_data_entity_scroll(client: Vtex, acronym):
+    result = client.master_data.get_data_entity_scroll(acronym)
     assert result.status_code == OK
 
 
-@pytest.mark.skip("working for now")
-def test_get_clients_next_scroll(client: Vtex):
-    initial = client.master_data.get_clients_scroll()
-    result = client.master_data.get_clients_next_scroll(initial.token)
+# @pytest.mark.skip("working for now")
+def test_get_data_entity_next_scroll(client: Vtex, acronym):
+    initial = client.master_data.get_data_entity_scroll(acronym)
+    result = client.master_data.get_data_entity_next_scroll(initial.token)
+    assert result.status_code == OK
+
+
+def test_get_data_entities_list(client: Vtex):
+    result = client.master_data.get_data_entities_list()
+    assert result.status_code == OK
+
+
+def test_get_data_entity_schema(client: Vtex, acronym):
+    result = client.master_data.get_data_entity_schema(acronym)
     assert result.status_code == OK

--- a/vtex/api_collections/master_data.py
+++ b/vtex/api_collections/master_data.py
@@ -8,7 +8,7 @@ class MasterDataApi(BaseApi):
         return url
 
     def _scroll_url(self):
-        url = f"https://{self.account_name}.vtexcommercestable.com.br/api/dataentities/CL/scroll"
+        url = f"https://{self.account_name}.vtexcommercestable.com.br/api/dataentities/{self.acronym}/scroll"
         return url
 
     def get_profile_by_email(self, email):
@@ -21,11 +21,20 @@ class MasterDataApi(BaseApi):
         url = self._build_url(endpoint)
         return self.get_result(url)
 
-    def get_clients_scroll(self):
+    def get_data_entities_list(self):
+        url = self.base_url + "/api/dataentities/"
+        return self.get_result(url)
+    
+    def get_data_entity_schema(self, acronym):
+        url = self.base_url + f"/api/dataentities/{acronym}/schemas"
+        return self.get_result(url)
+
+    def get_data_entity_scroll(self, acronym):
+        self.acronym = acronym
         url = self._scroll_url() + "?_size=1000"
         result = self.get_result(url)
         return result
 
-    def get_clients_next_scroll(self, token):
+    def get_data_entity_next_scroll(self, token):
         next_url = self._scroll_url() + f"?_token={token}"
         return self.get_result(next_url)


### PR DESCRIPTION
I propose an improvement to the master_data api: 

1 - make the "scroll" function more embracing where you can pull data from all the data entities available in the vtex account.

2 - to help the scroll function, I created the "get_data_entities_list", where you can pull the available acronym for fetching the scroll function.

3 - finally, an additional function helps to understand data schema of the data entities. Using the "get_data_entity_schema" you can get detailed info about the present data.

obs: tests for master_data are adjusted for new functions.

thanks.